### PR TITLE
Roguelikes log integration

### DIFF
--- a/lib/bot.ts
+++ b/lib/bot.ts
@@ -16,7 +16,7 @@ import {
 } from './formatting.ts';
 import { DEFAULT_NICK_COLORS, wrap } from './colors.ts';
 import { Dictionary, forEachAsync, invert, replaceAsync } from './helpers.ts';
-import { Config } from './config.ts';
+import { Config, GameLogConfig, IgnoreConfig } from './config.ts';
 import {
   createIrcActionListener,
   createIrcErrorListener,
@@ -60,6 +60,8 @@ export default class Bot {
   options: Config;
   channels: string[];
   webhookOptions: Dictionary<string>;
+  ignoreConfig?: IgnoreConfig;
+  gameLogConfig?: GameLogConfig;
   formatIRCText: string;
   formatURLAttachment: string;
   formatCommandPrelude: string;
@@ -100,6 +102,9 @@ export default class Bot {
     if (options.allowRolePings === undefined) {
       options.allowRolePings = true;
     }
+
+    this.gameLogConfig = options.gameLogConfig;
+    this.ignoreConfig = options.ignoreConfig;
 
     // "{$keyName}" => "variableValue"
     // displayUsername: nickname with wrapped colors
@@ -492,8 +497,27 @@ export default class Bot {
     return str1.toUpperCase().startsWith(str2.toUpperCase());
   }
 
-  async sendToDiscord(author: string, channel: string, text: string) {
-    const discordChannel = await this.findDiscordChannel(channel);
+  static shouldIgnoreMessage(
+    text: string,
+    ircChannel: string,
+    config: IgnoreConfig,
+  ): boolean {
+    for (const pattern of config.ignorePatterns[ircChannel]) {
+      if (text.indexOf(pattern) !== -1) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  async sendToDiscord(author: string, ircChannel: string, text: string) {
+    if (
+      this.ignoreConfig &&
+      Bot.shouldIgnoreMessage(text, ircChannel, this.ignoreConfig)
+    ) {
+      return;
+    }
+    const discordChannel = await this.findDiscordChannel(ircChannel);
     if (!discordChannel) return;
     const channelName = discordChannel.mention;
 
@@ -503,7 +527,7 @@ export default class Bot {
     }
 
     // Convert text formatting (bold, italics, underscore)
-    const withFormat = formatFromIRCToDiscord(text);
+    const withFormat = formatFromIRCToDiscord(text, author, this.gameLogConfig);
 
     const patternMap = {
       author,
@@ -511,7 +535,7 @@ export default class Bot {
       displayUsername: author,
       text: withFormat,
       discordChannel: `#${channelName}`,
-      ircChannel: channel,
+      ircChannel: ircChannel,
       withMentions: '',
       side: '',
     };
@@ -598,11 +622,11 @@ export default class Bot {
     );
 
     // Webhooks first
-    const webhook = this.findWebhook(channel);
+    const webhook = this.findWebhook(ircChannel);
     if (webhook) {
       if (discordChannel.isGuildText()) {
         this.debug && this.logger.debug(
-          `Sending message to Discord via webhook ${withMentions} ${channel} -> #${discordChannel.name}`,
+          `Sending message to Discord via webhook ${withMentions} ${ircChannel} -> #${discordChannel.name}`,
         );
       }
       if (this.discord.user === null) return;
@@ -613,7 +637,7 @@ export default class Bot {
         canPingEveryone = permissions.has(discord.Permissions.FLAGS.MENTION_EVERYONE);
       }
       */
-      const avatarURL = (await this.getDiscordAvatar(author, channel)) ??
+      const avatarURL = (await this.getDiscordAvatar(author, ircChannel)) ??
         undefined;
       const username = author.substring(0, USERNAME_MAX_LENGTH).padEnd(
         USERNAME_MIN_LENGTH,
@@ -650,7 +674,7 @@ export default class Bot {
     const withAuthor = Bot.substitutePattern(this.formatDiscord, patternMap);
     if (discordChannel.isGuildText()) {
       this.debug && this.logger.debug(
-        `Sending message to Discord ${withAuthor} ${channel} -> #${discordChannel.name}`,
+        `Sending message to Discord ${withAuthor} ${ircChannel} -> #${discordChannel.name}`,
       );
       discordChannel.send(withAuthor);
     }

--- a/lib/bot.ts
+++ b/lib/bot.ts
@@ -502,9 +502,11 @@ export default class Bot {
     ircChannel: string,
     config: IgnoreConfig,
   ): boolean {
-    for (const pattern of config.ignorePatterns[ircChannel]) {
-      if (text.indexOf(pattern) !== -1) {
-        return true;
+    for (const dict of config.ignorePatterns) {
+      for (const pattern of dict[ircChannel]) {
+        if (text.indexOf(pattern) !== -1) {
+          return true;
+        }
       }
     }
     return false;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -15,6 +15,19 @@ export type IgnoreUsers = {
   discordIds: string[];
 };
 
+export type GameLogConfig = {
+  patterns: {
+    [channel: string]: {
+      regex: string;
+      color: string;
+    };
+  };
+};
+
+type IgnoreConfig = {
+  ignorePatterns: { [channel: string]: string[] }[];
+};
+
 export type Config = {
   server: string;
   nickname: string;
@@ -29,6 +42,8 @@ export type Config = {
   announceSelfJoin?: boolean;
   webhooks?: Dictionary<string>;
   ignoreUsers?: IgnoreUsers;
+  gameLogconfig?: GameLogConfig;
+  ignoreConfig?: IgnoreConfig;
   // "{$keyName}" => "variableValue"
   // author/nickname: nickname of the user who sent the message
   // discordChannel: Discord channel (e.g. #general)

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -17,15 +17,16 @@ export type IgnoreUsers = {
 
 export type GameLogConfig = {
   patterns: {
-    [channel: string]: {
+    user: string;
+    matches: {
       regex: string;
       color: string;
-    };
-  };
+    }[];
+  }[];
 };
 
-type IgnoreConfig = {
-  ignorePatterns: { [channel: string]: string[] }[];
+export type IgnoreConfig = {
+  ignorePatterns: Dictionary<string[]>;
 };
 
 export type Config = {
@@ -42,7 +43,7 @@ export type Config = {
   announceSelfJoin?: boolean;
   webhooks?: Dictionary<string>;
   ignoreUsers?: IgnoreUsers;
-  gameLogconfig?: GameLogConfig;
+  gameLogConfig?: GameLogConfig;
   ignoreConfig?: IgnoreConfig;
   // "{$keyName}" => "variableValue"
   // author/nickname: nickname of the user who sent the message

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -26,7 +26,7 @@ export type GameLogConfig = {
 };
 
 export type IgnoreConfig = {
-  ignorePatterns: Dictionary<string[]>;
+  ignorePatterns: Dictionary<string[]>[];
 };
 
 export type Config = {


### PR DESCRIPTION
This change features integration for roguelikes servers to colorize and ignore log output from bots that post game status updates.

<img width="467" alt="image" src="https://github.com/aronson/discord-irc/assets/1026348/a2ddad92-2186-462b-bce8-6d2b099417fe">

Example snippet, note the channel and user names are on the IRC side:
```json
    "gameLogConfig": {
      "patterns": [
        {
          "user": "Luigi2",
          "matches": [{
            "regex": " was killed by | was annihilated by | was vaporized by | was destroyed by | was killed and destroyed by | was torn up by | was shredded by | was wasted by | was crushed by ",
            "color": "0;31"
          }, {
            "regex": "Morgoth, Lord of Darkness was slain by ",
            "color": "0;33"
          }, {
            "regex": "Michael, the Guardian Overlord was slain by |Bahamut, the Platinum King was slain by |The Living Lightning was slain by |Tik'srvzllat was slain by |The Hellraiser was slain by |Zu-Aon, The Cosmic Border Guard was slain by ",
            "color": "0;34"
          }]
        }
      ]
    },
    "ignoreConfig": {
      "ignorePatterns": [
        {
          "#cheems-test": [
            " has entered the game.",
            " has left the game."
          ]
        }
      ]
    },
```