### PR TITLE
Auto-create and reuse bot-owned webhooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ discord-irc
 logs
 *.log
 
+# WebStorm
+**/.idea/workspace.xml
+**/.idea/tasks.xml
+**/.idea/discord.xml
+
 # Runtime data
 pids
 *.pid

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/deno.xml
+++ b/.idea/deno.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DenoSettings">
+    <option name="useDeno" value="true" />
+  </component>
+</project>

--- a/.idea/discord-irc.iml
+++ b/.idea/discord-irc.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/discord-irc.iml" filepath="$PROJECT_DIR$/.idea/discord-irc.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -220,10 +220,8 @@ First you need to create a Discord bot user, which you can do by following the i
     "discord": ["discord_nick1", "discord_nick2"], // Ignore specified Discord nicks and do not send their messages to IRC.
     "discordIds": ["198528216523210752"] // Ignore specified Discord ids and do not send their messages to IRC.
   },
-  // List of webhooks per channel
-  "webhooks": {
-    "#discord": "https://discord.com/api/webhooks/id/token"
-  },
+  // Use webhooks
+  "webhooks": true,
   // Commands that will be sent on connect
   // Note: these are typically optional and only provided as a reference
   "autoSendCommands": [
@@ -247,15 +245,15 @@ Webhooks lets you override nicknames and avatars, so messages coming from IRC ca
 
 ![discord-webhook](http://i.imgur.com/lNeJIUI.jpg)
 
-To enable webhooks, follow part 1 of
-[this guide](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) to create and retrieve a webhook
-URL for a specific channel, then enable it in discord-irc's config as follows:
+To enable webhooks, enable them in discord-irc's config as follows:
 
 ```json
-"webhooks": {
-  "#discord-channel": "https://discord.com/api/webhooks/id/token"
-}
+"webhooks": {}
 ```
+
+The bot will automatically create and re-use its own webhooks.
+
+To disable webhooks, remove the `webhook` property from the config.
 
 ## Tests (TODO)
 

--- a/README.md
+++ b/README.md
@@ -253,8 +253,6 @@ To enable webhooks, enable them in discord-irc's config as follows:
 
 The bot will automatically create and re-use its own webhooks.
 
-To disable webhooks, remove the `webhooks` property from the config.
-
 ## Tests (TODO)
 
 Run the tests with:

--- a/README.md
+++ b/README.md
@@ -248,12 +248,12 @@ Webhooks lets you override nicknames and avatars, so messages coming from IRC ca
 To enable webhooks, enable them in discord-irc's config as follows:
 
 ```json
-"webhooks": {}
+"webhooks": true
 ```
 
 The bot will automatically create and re-use its own webhooks.
 
-To disable webhooks, remove the `webhook` property from the config.
+To disable webhooks, remove the `webhooks` property from the config.
 
 ## Tests (TODO)
 

--- a/lib/channelMapping.ts
+++ b/lib/channelMapping.ts
@@ -40,16 +40,15 @@ export class ChannelMapper {
       }
       // Check for webhook
       let webhookURL: string | null = null;
-      if (config.webhooks) {
-        if (config.webhooks['#' + discordChannel.name]) {
-          webhookURL = config.webhooks['#' + discordChannel.name];
-        } else if (config.webhooks[discordChannel.id]) {
-          webhookURL = config.webhooks[discordChannel.id];
-        }
-      }
       let client: Webhook | null = null;
-      if (webhookURL) {
-        client = await Webhook.fromURL(webhookURL, discord);
+      if (config.webhooks) {
+        const hookName = `${bot.config.nickname}_${discordChannel.name}`;
+        const hooks = await discordChannel.fetchWebhooks();
+        const hook = hooks.find((h) => h.name === hookName);
+        client = hook ?? await Webhook.create(discordChannel, discord, {
+          name: hookName,
+        });
+        webhookURL = client.url;
       }
       const mapping: ChannelMapping = {
         discordChannel: discordChannel,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -49,7 +49,7 @@ export type Config = {
   parallelPingFix?: boolean;
   ircStatusNotices?: boolean;
   announceSelfJoin?: boolean;
-  webhooks?: Dictionary<string>;
+  webhooks?: unknown;
   ignoreUsers?: IgnoreUsers;
   gameLogConfig?: GameLogConfig;
   ignoreConfig?: IgnoreConfig;
@@ -116,7 +116,7 @@ export const ConfigSchema = z.object({
   parallelPingFix: z.boolean().optional(),
   ircStatusNotices: z.boolean().optional(),
   announceSelfJoin: z.boolean().optional(),
-  webhooks: z.record(z.string()).optional(),
+  webhooks: z.unknown().optional(),
   ignoreUsers: IgnoreUsersSchema.optional(),
   gameLogConfig: GameLogConfigSchema.optional(),
   ignoreConfig: IgnoreConfigSchema.optional(),

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -49,7 +49,7 @@ export type Config = {
   parallelPingFix?: boolean;
   ircStatusNotices?: boolean;
   announceSelfJoin?: boolean;
-  webhooks?: unknown;
+  webhooks?: boolean;
   ignoreUsers?: IgnoreUsers;
   gameLogConfig?: GameLogConfig;
   ignoreConfig?: IgnoreConfig;
@@ -116,7 +116,7 @@ export const ConfigSchema = z.object({
   parallelPingFix: z.boolean().optional(),
   ircStatusNotices: z.boolean().optional(),
   announceSelfJoin: z.boolean().optional(),
-  webhooks: z.unknown().optional(),
+  webhooks: z.boolean().optional(),
   ignoreUsers: IgnoreUsersSchema.optional(),
   gameLogConfig: GameLogConfigSchema.optional(),
   ignoreConfig: IgnoreConfigSchema.optional(),

--- a/lib/discordClient.ts
+++ b/lib/discordClient.ts
@@ -25,6 +25,7 @@ export class DiscordClient extends Client {
         GatewayIntents.GUILD_MEMBERS,
         GatewayIntents.GUILD_MESSAGES,
         GatewayIntents.MESSAGE_CONTENT,
+        GatewayIntents.GUILD_WEBHOOKS,
       ],
       token: discordToken,
     });

--- a/lib/discordClient.ts
+++ b/lib/discordClient.ts
@@ -25,7 +25,6 @@ export class DiscordClient extends Client {
         GatewayIntents.GUILD_MEMBERS,
         GatewayIntents.GUILD_MESSAGES,
         GatewayIntents.MESSAGE_CONTENT,
-        GatewayIntents.GUILD_WEBHOOKS,
       ],
       token: discordToken,
     });


### PR DESCRIPTION
The bot can create its own webhooks. I wrote this a while ago.

Idea:
- Bot creates its own webhooks when reading channel list in channelMapping.ts
- Bot searches for existing webhooks by channel and webhook name
- config.json now only cares if webhook field defined whatsoever to enable (matches original behavior)
- Mixed states of some webhook and some non-webhook no longer supported (could add back later)
