### PR TITLE
Enable `compilerOptions.experimentalDecorators` for compatibility with Deno 1.41

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "experimentalDecorators": true
+  },
   "lint": {
     "include": ["lib/", "test/", "discord-irc.ts"],
     "rules": {


### PR DESCRIPTION
Deno 1.41 have an entirely different Decorator API, and libraries we use (mainly Harmony) is not ported to it. To get benefits of smaller `deno compile` and native ARM64 Linux outputs, we allow old Decorator API for now.