### PR TITLE
Pin Harmony Version to Fix CD

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,18 +84,13 @@ jobs:
 
       - name: Compile AMD64 binary for Windows
         if: runner.os == 'Windows'
-        run:
-          deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write \
-          --output discord-irc-${{ steps.os-suffix.outputs.result }}-amd64.exe discord-irc.ts
+        run: deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write --output discord-irc-${{ steps.os-suffix.outputs.result }}-amd64.exe discord-irc.ts
 
       - name: Compile AMD64 and ARM64 binaries for macOS and Linux
         if: runner.os != 'Windows'
         run: |
-          deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write \
-            --output discord-irc-${{ steps.os-suffix.outputs.result }}-amd64 discord-irc.ts
-          deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write \
-            --output discord-irc-${{ steps.os-suffix.outputs.result }}-arm64 \
-            --target ${{ steps.os-suffix.outputs.result == 'macos' && 'aarch64-apple-darwin' || 'aarch64-unknown-linux-gnu' }} discord-irc.ts
+          deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write --output discord-irc-${{ steps.os-suffix.outputs.result }}-amd64 discord-irc.ts
+          deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write --output discord-irc-${{ steps.os-suffix.outputs.result }}-arm64 --target ${{ steps.os-suffix.outputs.result == 'macos' && 'aarch64-apple-darwin' || 'aarch64-unknown-linux-gnu' }} discord-irc.ts
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,7 +86,7 @@ jobs:
         if: runner.os == 'Windows'
         run: deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write --output discord-irc-${{ steps.os-suffix.outputs.result }}-amd64.exe discord-irc.ts
 
-      - name: Compile AMD64 and ARM64 binaries for macOS and Linux
+      - name: Compile AMD64 and ARM64 binaries for ${{ runner.os }}
         if: runner.os != 'Windows'
         run: |
           deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write --output discord-irc-${{ steps.os-suffix.outputs.result }}-amd64 discord-irc.ts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,18 +58,13 @@ jobs:
 
       - name: Compile AMD64 binary for Windows
         if: runner.os == 'Windows'
-        run:
-          deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write \
-          --output discord-irc-${{ steps.os-suffix.outputs.result }}-amd64.exe discord-irc.ts
+        run: deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write --output discord-irc-${{ steps.os-suffix.outputs.result }}-amd64.exe discord-irc.ts
 
       - name: Compile AMD64 and ARM64 binaries for macOS and Linux
         if: runner.os != 'Windows'
         run: |
-          deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write \
-            --output discord-irc-${{ steps.os-suffix.outputs.result }}-amd64 discord-irc.ts
-          deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write \
-            --output discord-irc-${{ steps.os-suffix.outputs.result }}-arm64 \
-            --target ${{ steps.os-suffix.outputs.result == 'macos' && 'aarch64-apple-darwin' || 'aarch64-unknown-linux-gnu' }} discord-irc.ts
+          deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write --output discord-irc-${{ steps.os-suffix.outputs.result }}-amd64 discord-irc.ts
+          deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write --output discord-irc-${{ steps.os-suffix.outputs.result }}-arm64 --target ${{ steps.os-suffix.outputs.result == 'macos' && 'aarch64-apple-darwin' || 'aarch64-unknown-linux-gnu' }} discord-irc.ts
 
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
         if: runner.os == 'Windows'
         run: deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write --output discord-irc-${{ steps.os-suffix.outputs.result }}-amd64.exe discord-irc.ts
 
-      - name: Compile AMD64 and ARM64 binaries for macOS and Linux
+      - name: Compile AMD64 and ARM64 binaries for ${{ runner.os }}
         if: runner.os != 'Windows'
         run: |
           deno compile --allow-net --allow-env=CONFIG_FILE,DEBUG,VERBOSE,NODE_EXTRA_CA_CERTS --allow-read --allow-write --output discord-irc-${{ steps.os-suffix.outputs.result }}-amd64 discord-irc.ts

--- a/lib/deps.ts
+++ b/lib/deps.ts
@@ -15,12 +15,14 @@ export type { CtcpActionEvent } from 'https://deno.land/x/irc@v0.15.0/plugins/ac
 export type { InviteEvent } from 'https://deno.land/x/irc@v0.15.0/plugins/invite.ts';
 export type { AnyRawCommand } from 'https://deno.land/x/irc@v0.15.0/core/protocol.ts';
 export type { CtcpVersionEvent } from 'https://deno.land/x/irc@v0.15.0/plugins/version.ts';
+
 // Harmony/Discord exports
 export {
   AllowedMentionType,
   Client,
   Command,
   CommandClient,
+  type CommandContext,
   DiscordAPIError,
   event,
   GatewayIntents,
@@ -34,29 +36,33 @@ export {
   Role,
   slash,
   SlashCommandOptionType,
+  type SlashCommandPartial,
   User,
   Webhook,
-} from 'https://raw.githubusercontent.com/harmonyland/harmony/main/mod.ts';
-export type {
-  CommandContext,
-  SlashCommandPartial,
-} from 'https://raw.githubusercontent.com/harmonyland/harmony/main/mod.ts';
-export type { AllWebhookMessageOptions } from 'https://raw.githubusercontent.com/harmonyland/harmony/main/src/structures/webhook.ts';
+} from 'https://raw.githubusercontent.com/harmonyland/harmony/1821fc19428def11f468102631b9c53f37036f0b/mod.ts';
+export type { AllWebhookMessageOptions } from 'https://raw.githubusercontent.com/harmonyland/harmony/1821fc19428def11f468102631b9c53f37036f0b/src/structures/webhook.ts';
+
 // std exports
 export { resolve as resolvePath } from 'https://deno.land/std@0.203.0/path/mod.ts';
 export { parse as parseCLI } from 'https://deno.land/std@0.203.0/flags/mod.ts';
 export { parse as parseJSONC } from 'https://deno.land/std@0.203.0/jsonc/mod.ts';
+
 // Logging
 import Dlog from 'https://deno.land/x/dlog2@2.0/classic.ts';
 export { Dlog };
+
 // PluralKit support
 export { APIError, Member as PKMember, PKAPI } from 'https://deno.land/x/pkapi@v6.0.1/lib/mod.ts';
+
 // Queue
 export { Queue } from 'https://deno.land/x/queue@1.2.0/mod.ts';
+
 // Time to Live cache
 import TTL from 'https://deno.land/x/ttl@1.0.1/mod.ts';
 export { TTL };
+
 // Event handler
 export { Reflect } from 'https://deno.land/x/reflect_metadata@v0.1.12/mod.ts';
+
 // Regex escape
 export { escapeStringRegexp } from 'https://deno.land/x/escape_string_regexp@v0.0.1/mod.ts';

--- a/lib/deps.ts
+++ b/lib/deps.ts
@@ -43,9 +43,9 @@ export {
 export type { AllWebhookMessageOptions } from 'https://raw.githubusercontent.com/harmonyland/harmony/1821fc19428def11f468102631b9c53f37036f0b/src/structures/webhook.ts';
 
 // std exports
-export { resolve as resolvePath } from 'https://deno.land/std@0.203.0/path/mod.ts';
-export { parse as parseCLI } from 'https://deno.land/std@0.203.0/flags/mod.ts';
-export { parse as parseJSONC } from 'https://deno.land/std@0.203.0/jsonc/mod.ts';
+export { resolve as resolvePath } from 'https://deno.land/std@0.218.2/path/mod.ts';
+export { parse as parseCLI } from 'https://deno.land/std@0.218.2/flags/mod.ts';
+export { parse as parseJSONC } from 'https://deno.land/std@0.218.2/jsonc/mod.ts';
 
 // Logging
 import Dlog from 'https://deno.land/x/dlog2@2.0/classic.ts';


### PR DESCRIPTION
Also removes backslashes from commands, for some reason Deno doesn't like them.

[Tested it, and it works](https://github.com/catuhana/discord-irc/actions/runs/8118184182). Docker one fails because of an unrelated reason.