### PR TITLE
Exit on IRC read error (ping timeout)

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -65,6 +65,7 @@ export type Config = {
   logFolder?: string;
   pluralKit?: boolean;
   pkCacheSeconds?: number;
+  exitOnReadError?: boolean;
 };
 
 export const FormatSchema = z.object({
@@ -127,6 +128,7 @@ export const ConfigSchema = z.object({
   logFolder: z.string().optional(),
   pluralKit: z.boolean().optional(),
   pkCacheSeconds: z.number().optional(),
+  exitOnReadError: z.boolean().optional(),
 });
 
 const ConfigArraySchema = z.array(ConfigSchema);

--- a/lib/ircClient.ts
+++ b/lib/ircClient.ts
@@ -120,7 +120,7 @@ export class CustomIrcClient extends IrcClient {
   onError(error: ClientError) {
     console.log(error);
     if (this.exitOnReadError) {
-      Deno.exit();
+      Deno.exit(1);
     }
   }
   bindNotify(

--- a/lib/ircClient.ts
+++ b/lib/ircClient.ts
@@ -40,6 +40,7 @@ export class CustomIrcClient extends IrcClient {
   ircStatusNotices?: boolean;
   autoSendCommands?: string[][];
   announceSelfJoin?: boolean;
+  exitOnReadError?: boolean;
   constructor(clientOptions: ClientOptions, bot: Bot) {
     super(clientOptions);
     if (!bot.channelMapping) throw new Error('Cannot init IRC client without channel mapper');
@@ -51,6 +52,7 @@ export class CustomIrcClient extends IrcClient {
     this.channelMapping = bot.channelMapping;
     this.ircStatusNotices = bot.config.ircStatusNotices;
     this.announceSelfJoin = bot.config.announceSelfJoin;
+    this.exitOnReadError = bot.config.exitOnReadError;
     this.exiting = () => bot.exiting;
     this.bindEvents();
     this.sendExactToDiscord = async () => {};
@@ -116,9 +118,10 @@ export class CustomIrcClient extends IrcClient {
   }
   @Event('error')
   onError(error: ClientError) {
-    this.logger.error(
-      `Received error event from IRC\n${JSON.stringify(error, null, 2)}`,
-    );
+    console.log(error);
+    if (this.exitOnReadError) {
+      Deno.exit();
+    }
   }
   bindNotify(
     fn: (author: string, channel: string, message: string, raw: boolean) => Promise<void>,


### PR DESCRIPTION
## Problem

The bot sometimes gets a ping timeout on Libera and fails to reconnect, appearing as a generic "read error" in the logs.

## Solution

Promote the error output to show all metadata and allow for optional `exitOnReadError` logic.

When this config property is set to true, the bot will terminate the program when a ping timeout occurs. This is intended for use with docker, k8s, or systemd environments where some management software will restart the discord-irc program or container automatically on exit.
